### PR TITLE
Improve numerical stability of Smith G1 function and remove unused code

### DIFF
--- a/impl/openpbr_coating_lobe.h
+++ b/impl/openpbr_coating_lobe.h
@@ -23,7 +23,7 @@
 // Specify the type of lobe representing reflection from the coating.
 #include "openpbr_ior_reflection_coefficient.h"
 #include "openpbr_microfacet_multiple_scattering_data.h"
-#include "openpbr_vndf_microfacet_distributions.h"
+#include "openpbr_vndf_microfacet_distribution.h"
 #define OPENPBR_MICROFACET_DISTRIBUTION_TYPE OpenPBR_AnisotropicGGXSmithVNDFMicrofacetDistribution
 #define OPENPBR_REFLECTION_COEFFICIENT_TYPE OpenPBR_IorReflectionCoefficient
 #define OPENPBR_MINIMAL_MICROFACET_LOBE_TYPE                                                                                                         \

--- a/impl/openpbr_comprehensive_microfacet_lobe.h
+++ b/impl/openpbr_comprehensive_microfacet_lobe.h
@@ -24,7 +24,7 @@
 #include "openpbr_dispersion_utils.h"
 #include "openpbr_lobe_utils.h"
 #include "openpbr_specialization_constants.h"
-#include "openpbr_vndf_microfacet_distributions.h"
+#include "openpbr_vndf_microfacet_distribution.h"
 
 ///////////////////////////////////////////////////////
 // ComprehensiveMicrofacetReflectionTransmissionLobe //

--- a/impl/openpbr_lobe_utils.h
+++ b/impl/openpbr_lobe_utils.h
@@ -71,24 +71,6 @@ vec2 openpbr_compute_anisotropic_alpha(const float isotropic_alpha,
     return anisotropic_alpha;
 }
 
-// Evaluate isotropic Smith shadowing or masking function.
-float openpbr_eval_iso_smith_g1(const float cos_theta, const float alpha)
-{
-    if (cos_theta <= 0.0f)
-        return 0.0f;
-    const float c2 = openpbr_square(cos_theta);
-    const float t2 = (1.0f - c2) / c2;
-    const float a2 = openpbr_square(alpha);
-    const float tmp = openpbr_fast_sqrt(1.0f + a2 * t2);
-    return 2.0f / (1.0f + tmp);
-}
-
-// Evaluate isotropic Smith shadowing and masking function.
-float openpbr_eval_iso_smith_g2(const float cos1, const float cos2, const float alpha)
-{
-    return openpbr_eval_iso_smith_g1(cos1, alpha) * openpbr_eval_iso_smith_g1(cos2, alpha);
-}
-
 // Evaluate anisotropic GGX.
 // Input vector is in local (z-up) space.
 float openpbr_eval_aniso_ggx(const vec3 n, const vec2 alpha)

--- a/impl/openpbr_lobe_utils.h
+++ b/impl/openpbr_lobe_utils.h
@@ -132,15 +132,19 @@ vec3 openpbr_sample_aniso_ggx_smith_vndf(const vec2 alpha, const vec3 incoming, 
 
 // Evaluate anisotropic Smith shadowing or masking function.
 // Input vector is in local (z-up) space.
+// Negative v.z is intentionally supported to accommodate transmission paths.
 float openpbr_eval_aniso_smith_g1(const vec3 v, const vec2 alpha)
 {
-    if (v.z == 0.0f)
+    // Guard against division by zero; underflow in the square automatically
+    // handles cases where v is near the tangent plane.
+    const float vz_squared = openpbr_square(v.z);
+    if (vz_squared == 0.0f)
         return 0.0f;
-    const float lambda =
-        (-1.0f + openpbr_fast_sqrt(1.0f + (openpbr_square(alpha.x) * openpbr_square(v.x) + openpbr_square(alpha.y) * openpbr_square(v.y)) /
-                                              openpbr_square(v.z))) /
-        2.0f;
-    return 1.0f / (1.0f + lambda);
+
+    // This uses an algebraically equivalent form of the Smith G1 function that
+    // avoids catastrophic cancellation in the intermediate Lambda computation,
+    // ensuring numerical stability when roughness or slopes are near zero.
+    return 2.0f / (1.0f + openpbr_fast_sqrt(1.0f + (openpbr_square(alpha.x * v.x) + openpbr_square(alpha.y * v.y)) / vz_squared));
 }
 
 // Evaluate anisotropic Smith non-correlated shadowing and masking function.

--- a/impl/openpbr_thin_wall_specular_transmission_lobe.h
+++ b/impl/openpbr_thin_wall_specular_transmission_lobe.h
@@ -23,7 +23,7 @@
 // Specify the type of lobe that is used for the thin-wall specular reflection and transmission.
 #include "openpbr_constant_reflection_coefficient.h"
 #include "openpbr_microfacet_multiple_scattering_data.h"
-#include "openpbr_vndf_microfacet_distributions.h"
+#include "openpbr_vndf_microfacet_distribution.h"
 #define OPENPBR_MICROFACET_DISTRIBUTION_TYPE OpenPBR_AnisotropicGGXSmithVNDFMicrofacetDistribution
 #define OPENPBR_REFLECTION_COEFFICIENT_TYPE OpenPBR_ConstantReflectionCoefficient
 #define OPENPBR_MINIMAL_MICROFACET_LOBE_TYPE                                                                                                         \

--- a/impl/openpbr_vndf_microfacet_distribution.h
+++ b/impl/openpbr_vndf_microfacet_distribution.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
-#ifndef OPENPBR_VNDF_MICROFACET_DISTRIBUTIONS_H
-#define OPENPBR_VNDF_MICROFACET_DISTRIBUTIONS_H
+#ifndef OPENPBR_VNDF_MICROFACET_DISTRIBUTION_H
+#define OPENPBR_VNDF_MICROFACET_DISTRIBUTION_H
 
 #include "../openpbr_basis.h"
 #include "openpbr_lobe_utils.h"
@@ -86,62 +86,4 @@ float openpbr_get_isotropic_alpha(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF
     return microfacet_distr.isotropic_alpha;
 }
 
-/////////////////////////////////////////////////
-// IsotropicGGXSmithVNDFMicrofacetDistribution //
-/////////////////////////////////////////////////
-
-struct OpenPBR_IsotropicGGXSmithVNDFMicrofacetDistribution
-{
-    float alpha;
-};
-
-vec3 openpbr_sample_ggx_smith_vndf(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_IsotropicGGXSmithVNDFMicrofacetDistribution)
-                                       microfacet_distr,
-                                   const vec3 view_direction,
-                                   const vec3 normal_ff,
-                                   const vec2 rand)
-{
-    // Construct a temporary frame.
-    const OpenPBR_Basis basis_ff = openpbr_make_basis(normal_ff);
-
-    // Choose microfacet normal (in local space).
-    const vec3 half_vector_local =
-        openpbr_sample_aniso_ggx_smith_vndf(vec2(microfacet_distr.alpha), openpbr_world_to_local(basis_ff, view_direction), rand);
-    OPENPBR_ASSERT(half_vector_local.z >= 0.0f, "Bad half vector");
-
-    // Map half vector to world.
-    return openpbr_local_to_world(basis_ff, half_vector_local);
-}
-
-float openpbr_eval_ggx(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_IsotropicGGXSmithVNDFMicrofacetDistribution) microfacet_distr,
-                       const vec3 half_vector,
-                       const vec3 normal_ff)
-{
-    // For the isotropic case this is algebraically equivalent to evaluating isotropic GGX from abs(dot(half_vector, normal_ff)),
-    // but this local-space form is more numerically stable at low roughnesses.
-    return openpbr_eval_aniso_ggx(openpbr_world_to_local(openpbr_make_basis(normal_ff), half_vector), vec2(microfacet_distr.alpha));
-}
-
-float openpbr_eval_smith_g1(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_IsotropicGGXSmithVNDFMicrofacetDistribution) microfacet_distr,
-                            const vec3 view_direction_or_light_direction,
-                            float iodotn)
-{
-    return openpbr_eval_iso_smith_g1(abs(iodotn), microfacet_distr.alpha);
-}
-
-float openpbr_eval_smith_g2(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_IsotropicGGXSmithVNDFMicrofacetDistribution) microfacet_distr,
-                            const vec3 view_direction,
-                            const vec3 light_direction,
-                            float idotn,
-                            float odotn)
-{
-    return openpbr_eval_iso_smith_g2(abs(idotn), abs(odotn), microfacet_distr.alpha);
-}
-
-float openpbr_get_isotropic_alpha(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_IsotropicGGXSmithVNDFMicrofacetDistribution)
-                                      microfacet_distr)
-{
-    return microfacet_distr.alpha;
-}
-
-#endif  // !OPENPBR_VNDF_MICROFACET_DISTRIBUTIONS_H
+#endif  // !OPENPBR_VNDF_MICROFACET_DISTRIBUTION_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR does some cleanup related to recent PRs. Specifically, it simplifies the anisotropic Smith G1 function to improve numerical stability and performance, documents that function more clearly, and removes some related unused code (the isotropic version of the microfacet distribution).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/openpbr-bsdf/issues/16

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improves edge-case behavior and usability.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in minimal C++ example program and other integrations.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
