### PR TITLE
OpenPBR anisotropy rotation optimization, small fixes, and documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ OpenPBR 1.1 defines `specular_roughness_anisotropy` and `coat_roughness_anisotro
 | `specular_anisotropy_rotation_cos_sin` | `vec2` | `(1, 0)` | (cos θ, sin θ) of the specular anisotropy rotation |
 | `coat_anisotropy_rotation_cos_sin`     | `vec2` | `(1, 0)` | (cos θ, sin θ) of the coat anisotropy rotation     |
 
-Both default to `(1, 0)` = (cos 0°, sin 0°), which is a no-op equivalent to having no rotation at all. The vec2 does not need to be unit-length (as can happen after texture filtering); the BSDF normalizes the rotated tangent frame internally.
+Both default to `(1, 0)` = (cos 0°, sin 0°), which is a no-op equivalent to having no rotation at all. The vec2 does not need to be unit-length (as can happen after texture filtering); the BSDF normalizes it internally and treats `(0, 0)` as no rotation.
 
 This representation is used for two main reasons:
 
@@ -345,6 +345,10 @@ When sourcing rotation from a scalar angle (e.g., a material parameter rather th
 Thin-film iridescence and thin-walled transmission are not currently compatible: when `geometry_thin_walled` is enabled, iridescence is not visible on the transmission component. (Thin-walled subsurface scattering is unaffected and shows iridescence normally.)
 
 Note that thin-walled mode is not the right tool for soap-bubble or iridescent membrane effects regardless of this limitation — it models an incoherent two-surface windowpane (suited to thick glass), not a nanometer-scale interference coating. For those effects, use a *closed solid surface* (`geometry_thin_walled = false`) with the interior specular IOR set to 1.0 (air) and thin film enabled.
+
+### CUDA Backend: Vector Types
+
+The CUDA interop header aliases `vec2`/`vec3`/`vec4` to CUDA's `float2`/`float3`/`float4` plain structs, which lack the constructors and operators the OpenPBR codebase relies on. As a workaround, set `OPENPBR_USE_CUSTOM_VEC_TYPES=1` and provide compatible vector types before including `openpbr.h`.
 
 ---
 

--- a/impl/openpbr_bsdf.h
+++ b/impl/openpbr_bsdf.h
@@ -21,8 +21,8 @@
 #include "../openpbr_bsdf_lobe_type.h"
 #include "../openpbr_constants.h"
 #include "../openpbr_diffuse_specular.h"
-#include "../openpbr_resolved_inputs.h"
 #include "../openpbr_homogeneous_volume.h"
+#include "../openpbr_resolved_inputs.h"
 
 #include "openpbr_dispersion_utils.h"
 #include "openpbr_fuzz_lobe.h"  // only need to include outermost lobe
@@ -266,6 +266,19 @@ vec3 openpbr_compute_final_transmission_tint(const vec3 transmission_tint,
     return pow(transmission_tint, vec3(path_length));
 }
 
+// Applies an anisotropy rotation to an orthonormal basis.
+// The input cos_sin is normalized because filtered texture lookups can turn unit (cos, sin) pairs into non-unit vectors.
+// This preserves basis orthonormality without output renormalization.
+// Zero is treated as no rotation.
+OPENPBR_INLINE_FUNCTION void openpbr_apply_anisotropy_rotation(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_INOUT(OpenPBR_Basis) basis, const vec2 cos_sin)
+{
+    if (all(equal(cos_sin, vec2(0.0f))))
+        return;
+
+    const vec2 normalized_cos_sin = openpbr_fast_normalize(cos_sin);
+    openpbr_rotate_basis_around_normal(basis, normalized_cos_sin);
+}
+
 // Sets up BSDF lobes from resolved inputs and caches view_direction in "prepared".
 // Populates prepared.fuzz_lobe and prepared.view_direction; does not touch prepared.volume or prepared.emission.
 //
@@ -299,9 +312,7 @@ void openpbr_prepare_lobes(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPB
 
     // Set up normal_ff, the forward-facing version of the shading normal.
     OpenPBR_Basis specular_anisotropy_basis_ff = resolved_inputs.geometry_basis;
-    openpbr_rotate_basis_around_normal(specular_anisotropy_basis_ff, resolved_inputs.specular_anisotropy_rotation_cos_sin);
-    specular_anisotropy_basis_ff.t = normalize(specular_anisotropy_basis_ff.t);
-    specular_anisotropy_basis_ff.b = normalize(specular_anisotropy_basis_ff.b);
+    openpbr_apply_anisotropy_rotation(specular_anisotropy_basis_ff, resolved_inputs.specular_anisotropy_rotation_cos_sin);
 
     if (back_facing)
     {
@@ -315,9 +326,7 @@ void openpbr_prepare_lobes(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPB
     // Make coat_normal_ff depend on geometry_coat_basis.n instead of geometry_basis.n
     // and update the coat normal basis to be in the same hemisphere as the view direction.
     OpenPBR_Basis coat_anisotropy_basis_ff = resolved_inputs.geometry_coat_basis;
-    openpbr_rotate_basis_around_normal(coat_anisotropy_basis_ff, resolved_inputs.coat_anisotropy_rotation_cos_sin);
-    coat_anisotropy_basis_ff.t = normalize(coat_anisotropy_basis_ff.t);
-    coat_anisotropy_basis_ff.b = normalize(coat_anisotropy_basis_ff.b);
+    openpbr_apply_anisotropy_rotation(coat_anisotropy_basis_ff, resolved_inputs.coat_anisotropy_rotation_cos_sin);
 
     if (dot(view_direction, resolved_inputs.geometry_coat_basis.n) < 0.0f)  // back-facing coat
         openpbr_invert_basis(coat_anisotropy_basis_ff);

--- a/impl/openpbr_math.h
+++ b/impl/openpbr_math.h
@@ -22,7 +22,7 @@
 //
 //   #define OPENPBR_FAST_RCP_SQRT(x)  fast_rcp_sqrt(x)   // fast 1/sqrt(x) for float x
 //   #define OPENPBR_FAST_SQRT(x)      fast_sqrt(x)       // fast sqrt(x) for float x
-//   #define OPENPBR_FAST_NORMALIZE(v) fast_normalize(v)  // fast normalize(v) for vec3 v
+//   #define OPENPBR_FAST_NORMALIZE(v) fast_normalize(v)  // fast normalize(v) for vec2 and vec3 v
 //
 // OPENPBR_FAST_SQRT is also applied component-wise to vec3 arguments.
 
@@ -40,6 +40,7 @@
 OPENPBR_INLINE_FUNCTION float openpbr_fast_rcp_sqrt(const float x) { return OPENPBR_FAST_RCP_SQRT(x); }
 OPENPBR_INLINE_FUNCTION float openpbr_fast_sqrt(const float x)     { return OPENPBR_FAST_SQRT(x); }
 OPENPBR_INLINE_FUNCTION vec3  openpbr_fast_sqrt(const vec3 v)      { return vec3(OPENPBR_FAST_SQRT(v.x), OPENPBR_FAST_SQRT(v.y), OPENPBR_FAST_SQRT(v.z)); }
+OPENPBR_INLINE_FUNCTION vec2  openpbr_fast_normalize(const vec2 v) { return OPENPBR_FAST_NORMALIZE(v); }
 OPENPBR_INLINE_FUNCTION vec3  openpbr_fast_normalize(const vec3 v) { return OPENPBR_FAST_NORMALIZE(v); }
 // clang-format on
 

--- a/openpbr_bsdf_lobe_type.h
+++ b/openpbr_bsdf_lobe_type.h
@@ -23,12 +23,12 @@
 
 #define OpenPBR_BsdfLobeType OPENPBR_UINT32
 OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeNone = 0;
-OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeReflection = 1 << 0;
-OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeTransmission = 1 << 1;
-OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeDiffuse = 1 << 2;
-OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeGlossy = 1 << 3;
-OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeSpecular = 1 << 4;
-OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeVolume = 1 << 5;
+OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeReflection = OpenPBR_BsdfLobeType(1) << 0;
+OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeTransmission = OpenPBR_BsdfLobeType(1) << 1;
+OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeDiffuse = OpenPBR_BsdfLobeType(1) << 2;
+OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeGlossy = OpenPBR_BsdfLobeType(1) << 3;
+OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeSpecular = OpenPBR_BsdfLobeType(1) << 4;
+OPENPBR_CONSTEXPR_GLOBAL OpenPBR_BsdfLobeType OpenPBR_BsdfLobeTypeVolume = OpenPBR_BsdfLobeType(1) << 5;
 
 // Swap reflection and transmission in the OpenPBR_BsdfLobeType bitmask.
 OPENPBR_INLINE_FUNCTION OpenPBR_BsdfLobeType openpbr_swap_reflect_trans_flags(OpenPBR_BsdfLobeType bsdf_lobe_type)

--- a/openpbr_settings.h
+++ b/openpbr_settings.h
@@ -121,7 +121,7 @@
 //
 //   OPENPBR_FAST_RCP_SQRT(x)     — fast 1/sqrt(x) for float x
 //   OPENPBR_FAST_SQRT(x)         — fast sqrt(x) for float x  (also applied component-wise to vec3)
-//   OPENPBR_FAST_NORMALIZE(v)    — fast normalize(v) for vec3 v
+//   OPENPBR_FAST_NORMALIZE(v)    — fast normalize(v) for vec2 and vec3 v
 //
 // Example:
 //   #define OPENPBR_FAST_RCP_SQRT(x)  fast_rcp_sqrt(x)
@@ -220,7 +220,7 @@
 //
 //   OPENPBR_GET_SPECIALIZATION_CONSTANT(name)
 //       Default: true
-//       name is one of the four toggle names listed above, passed as a token.
+//       "name" is one of the four toggle names listed above, passed as a token.
 //       Override to return the corresponding bool through your renderer's
 //       specialization constant pipeline (Vulkan layout(constant_id),
 //       Metal function_constant, CPU runtime lookup, etc.).


### PR DESCRIPTION
## Description

This PR contains optimization and robustness improvements for the anisotropy rotation extension, as well as miscellaneous small fixes and documentation improvements. In particular, this PR makes the anisotropy rotation system more robust by officially supporting zero-valued cosine–sine pairs, and it makes the system more performant by normalizing the inputs 2D vectors instead of twice as many output 3D vectors.

## Related Issue

https://github.com/adobe/openpbr-bsdf/issues/24

## Motivation and Context

The Adobe OpenPBR BSDF includes anisotropy rotation parameters that aren't in the regular spec. As this parameterization was recently introduced, there was some room for improving robustness and performance. A few other small issues and limitations were noticed and fixed in the process.

## How Has This Been Tested?

Tested locally in renderer integrations.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.