### PR TITLE
Make OpenPBR fuzz and coat lobes energy-conserving instead of reciprocal by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Note: This is shared as a reference implementation, not run as a community-drive
 - **Single-include API:** `#include "openpbr.h"` brings in the complete public API — all types, settings, and the full BSDF.
 - **Multi-language support:** C++, GLSL, CUDA, MSL, or Slang from the same source via a thin interop layer.
 - **Self-contained:** No globals, no hidden dependencies — everything lives alongside the BSDF.
-- **Configurable:** Compile-time settings in `openpbr_settings.h` control LUT mode, fast math overrides, conflict-suppression hooks, specialization constants, and custom interop.
+- **Configurable:** Compile-time settings in `openpbr_settings.h` control LUT mode, coat/fuzz attenuation, fast math overrides, conflict-suppression hooks, specialization constants, and custom interop.
 - **Fixed-lobe architecture:** One struct per material component.
 - **Energy-conserving:** The BSDF is designed to be energy-conserving for most common configurations, using precomputed LUTs for multiple-scattering compensation.
-- **Reciprocal:** The BSDF satisfies Helmholtz reciprocity for most configurations. See [Path Tracing Direction](#path-tracing-direction) for the exception with transmission. (Note that reciprocity may be traded for better energy conservation in future versions.)
+- **Reciprocal:** The BSDF is reciprocal for most configurations. See [Path Tracing Direction](#path-tracing-direction) for the transmission, coat, and fuzz exceptions.
 
 ---
 
@@ -266,6 +266,8 @@ Actual volume integration — random walks, transmittance queries, shadow rays t
 
 This BSDF is designed for unidirectional path tracing from camera to lights. Bidirectional methods (photon mapping, light tracing) would require an adjoint BSDF with inverted square IOR scaling for transmission.
 
+For the coat and fuzz layers, `OPENPBR_RECIPROCAL_COAT_AND_FUZZ` trades energy conservation against reciprocity — this single-scatter layering can't have both. The default (`0`) omits the light-side reflection term: energy-conserving for camera-to-light transport but not the reverse (it's non-reciprocal). Setting it to `1` applies symmetric two-sided attenuation (at the cost of some darkening): fully reciprocal for the coat, and symmetric base attenuation for the fuzz, whose sheen LTC fit stays non-reciprocal. A light/photon tracer keeps the default's conservation by passing its fixed incident direction as `view`, though those values differ from the camera-direction evaluation.
+
 ### Sampling Return Behavior
 
 `openpbr_sample()` returns `void`, but indicates success/failure through the `pdf` output parameter:
@@ -356,15 +358,15 @@ The CUDA interop header aliases `vec2`/`vec3`/`vec4` to CUDA's `float2`/`float3`
 
 We welcome issues and pull requests, for example:
 
-- Enhancements to the simple demo app (with the goal of keeping it minimal, self-contained, and readable — it illustrates how to use the BSDF API, not how to build a renderer; more complex tests belong in a separate program)
-- Expanded unit tests for evaluation, sampling, and energy conservation
+- A small material-preview program that renders a sphere lit by a simple analytic environment and writes out an image, to visualize a given material configuration (kept separate from the minimal demo, which stays focused on illustrating the API)
+- Expanded unit tests for evaluation, sampling, and energy conservation — for example, a minimal white-furnace test over a range of material configurations
 - Testing of the CUDA backend, which hasn't yet been used in production code
 - Testing of the Slang backend in HLSL-style pipelines (and, if needed, adapting the Slang interop aliases or proposing a dedicated HLSL interop header)
 
 Planned or potential future work:
 
 - Specialization constants currently cover four per-lobe feature toggles (`EnableSheenAndCoat`, `EnableDispersion`, `EnableTranslucency`, `EnableMetallic`), all defaulting to `true`; more may be added (e.g., for thin-film and thin-wall) to cover additional lobes
-- Reciprocity may be traded for better energy conservation in a future version
+- The coat and fuzz layers trade reciprocity for better fixed-view energy conservation by default (see `OPENPBR_RECIPROCAL_COAT_AND_FUZZ`); a similar tradeoff may be extended to other lobes in the future
 - 1D texture sampler support: energy tables with a single dimension are currently stored as thin 2D textures (1 × N); using a real 1D sampler when the platform supports it would reduce sampler overhead
 - Implementing OpenPBR 1.2
 - Continued iteration on the implementation — some naming conventions and API details may evolve as this is live production code

--- a/impl/openpbr_coating_lobe.h
+++ b/impl/openpbr_coating_lobe.h
@@ -45,7 +45,7 @@
 /////////////////
 
 // Represents a coating layer and whatever is beneath it (the aggregate base lobe in this case).
-// Handles energy balance between these layers in a reciprocal way.
+// Handles the energy balance between these layers.
 // When "inside" is true, represents a coated surface hit from the inside;
 // applies a tint but doesn't do much else.
 struct OpenPBR_CoatingLobe_AggregateLobe
@@ -119,7 +119,11 @@ vec3 openpbr_base_layer_scale_outgoing(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONS
                                        const vec3 light_direction)
 {
     const float odotn = dot(light_direction, lobe.normal_ff);
+#if OPENPBR_RECIPROCAL_COAT_AND_FUZZ
     const float out_reflected = openpbr_proportion_reflected(lobe, odotn);
+#else
+    const float out_reflected = 0.0f;
+#endif
     return openpbr_base_layer_scale_one_side(lobe, odotn, out_reflected);
 }
 

--- a/impl/openpbr_fuzz_lobe.h
+++ b/impl/openpbr_fuzz_lobe.h
@@ -369,8 +369,11 @@ float openpbr_base_layer_scale_incoming(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CON
 float openpbr_base_layer_scale_outgoing(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_FuzzLobe_CoatingLobe_AggregateLobe) lobe,
                                         const vec3 light_direction_local)
 {
-    const float light_reflected = openpbr_proportion_reflected(lobe, light_direction_local);
-    return 1.0f - light_reflected;
+#if OPENPBR_RECIPROCAL_COAT_AND_FUZZ
+    return 1.0f - openpbr_proportion_reflected(lobe, light_direction_local);
+#else
+    return 1.0f;
+#endif
 }
 
 float openpbr_base_layer_scale_complete(OPENPBR_ADDRESS_SPACE_THREAD OPENPBR_CONST_REF(OpenPBR_FuzzLobe_CoatingLobe_AggregateLobe) lobe,

--- a/openpbr_settings.h
+++ b/openpbr_settings.h
@@ -24,6 +24,9 @@
 // Most users only need one setting:
 //   - OPENPBR_USE_TEXTURE_LUTS        — 0 (default, self-contained arrays) or 1 (GPU textures)
 //
+// Appearance / behavior:
+//   - OPENPBR_RECIPROCAL_COAT_AND_FUZZ — 0 (default, view-side attenuation) or 1 (symmetric attenuation)
+//
 // Auto-configured; override only if the default is wrong for your target:
 //   - OPENPBR_LANGUAGE_TARGET_*        — auto-detected from compiler macros; set explicitly for Slang
 //
@@ -108,6 +111,36 @@
 #ifndef OPENPBR_SAMPLE_3D_TEXTURE
 #error "OPENPBR_USE_TEXTURE_LUTS = 1 requires OPENPBR_SAMPLE_3D_TEXTURE to be defined before including openpbr.h."
 #endif
+#endif
+
+// ================================================
+// Coat / Fuzz Reciprocity vs. Energy Conservation
+// ================================================
+//
+// The coat and fuzz/sheen layers attenuate the layer beneath them by how much light the
+// interface reflects away (the layer's directional reflectance). This is separate from the
+// layers' absorption and tinting, which color the result, are always applied, and are
+// unaffected by this setting. Applying the reflection-based attenuation on both the view and
+// light sides is symmetric, but darkens the fixed-view white-furnace result because the model
+// does not otherwise redistribute the light-side reflection.
+//
+// OPENPBR_RECIPROCAL_COAT_AND_FUZZ = 0 (Default)
+//   - The light-side reflection term is omitted from base-layer attenuation.
+//   - Improves fixed-view energy conservation for camera-to-light path tracing, but is not
+//     reciprocal and provides no corresponding guarantee for transposed light transport.
+//   - View-side attenuation is unchanged.
+//
+// OPENPBR_RECIPROCAL_COAT_AND_FUZZ = 1
+//   - Applies symmetric view-side/light-side base-layer attenuation.
+//   - This makes the coat layering reciprocal, at the cost of some darkening. The view-dependent
+//     fuzz LTC fit remains non-reciprocal.
+//
+// Example:
+//   #define OPENPBR_RECIPROCAL_COAT_AND_FUZZ 1
+//   #include "openpbr.h"
+//
+#ifndef OPENPBR_RECIPROCAL_COAT_AND_FUZZ
+#define OPENPBR_RECIPROCAL_COAT_AND_FUZZ 0
 #endif
 
 // ===============


### PR DESCRIPTION
## Description

By default, the coat and fuzz layers now apply the interface reflection term only on the view side, not the light side. Applying it on both sides loses energy that the single-scatter layering can't redistribute, which darkened results and failed the fixed-view white-furnace test.

This PR drops the light-side term to conserve energy for camera-to-light transport. This makes the results match most other renderers, at the cost of strict reciprocity for these two layers.

This PR also introduces a new compile-time setting, `OPENPBR_RECIPROCAL_COAT_AND_FUZZ`, that optionaly restores the symmetric view/light attenuation. With it enabled, the coat layering is reciprocal and energy-bounded in both transport directions, while the view-keyed fuzz LTC fit remains non-reciprocal. Only the interface reflection term is affected; in-layer absorption and tinting (coat and fuzz color) are unchanged and still applied on both sides.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
